### PR TITLE
Fix installation

### DIFF
--- a/src/collective/cron/configure.zcml
+++ b/src/collective/cron/configure.zcml
@@ -25,7 +25,7 @@
       title="various setup for collective.cron"
       description="various setup for collective.cron"
       handler="collective.cron.setuphandlers.setupVarious">
-    <depends name="content"/>
+    <depends name="plone.app.registry"/>
   </genericsetup:importStep>
   <genericsetup:importStep
       name="collective.cron.setupCrons"


### PR DESCRIPTION
Looks like setupVarious assumes that the registry is already in place when run, which it is normally, but for some combinations of packages seems that it's not the case, thus not depending on content but on p.a.registry instead does the trick.
