### PR TITLE
Remove ipython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     include_package_data=True,
     extras_require = {
         'test': [
-            'plone.app.testing', 'ipython',
+            'plone.app.testing',
         ],
     },
     install_requires=[


### PR DESCRIPTION
I don't think ipython really needs to be on setup.py, that's something you install either on your buildout or you get it from python itself (either system wide or a virtualenv). 
