### PR TITLE
[WIP] Add a request object to the context when running a cron job

### DIFF
--- a/src/collective/cron/utils.py
+++ b/src/collective/cron/utils.py
@@ -16,8 +16,7 @@ from zope.testbrowser import browser
 from contextlib import contextmanager
 from croniter import croniter as baseT
 
-from ZPublisher.HTTPRequest import HTTPRequest
-from ZPublisher.HTTPResponse import HTTPResponse
+from Testing.makerequest import makerequest
 
 D = os.path.dirname
 J = os.path.join
@@ -185,22 +184,10 @@ def asbool(value):
 
 @contextmanager
 def context_with_request(context, cron):
-    # Create a request to work with
-    response = HTTPResponse(stdout=sys.stdout)
-
-    # Set up the request environment
+    # Get the request environment
     env = cron.environ.get('REQUEST', {})
 
-    # Required environment variables
-    if 'SERVER_NAME' not in env:
-        env['SERVER_NAME'] = 'localhost'
-    if 'SERVER_PORT' not in env:
-        env['SERVER_PORT'] = '80'
-
-    request = HTTPRequest(sys.stdin, env, response)
-    context.REQUEST = request
-
-    yield context
-    del context.REQUEST
+    # Use makerequest to set up the request properly
+    yield makerequest(context, environ=env)
 
 # vim:set et sts=4 ts=4 tw=80:

--- a/src/collective/cron/utils.py
+++ b/src/collective/cron/utils.py
@@ -11,6 +11,7 @@ import time
 import shutil
 
 from AccessControl.SecurityManagement import newSecurityManager
+from zope.site.hooks import getSite, setSite
 from zope.testbrowser import browser
 
 from contextlib import contextmanager
@@ -187,7 +188,12 @@ def context_with_request(context, cron):
     # Get the request environment
     env = cron.environ.get('REQUEST', {})
 
+    oldsite = getSite()
     # Use makerequest to set up the request properly
-    yield makerequest(context, environ=env)
+    context = makerequest(context, environ=env)
+    setSite(context)
+    yield context
+
+    setSite(oldsite)
 
 # vim:set et sts=4 ts=4 tw=80:

--- a/src/collective/cron/utils.py
+++ b/src/collective/cron/utils.py
@@ -13,7 +13,11 @@ import shutil
 from AccessControl.SecurityManagement import newSecurityManager
 from zope.testbrowser import browser
 
+from contextlib import contextmanager
 from croniter import croniter as baseT
+
+from ZPublisher.HTTPRequest import HTTPRequest
+from ZPublisher.HTTPResponse import HTTPResponse
 
 D = os.path.dirname
 J = os.path.join
@@ -177,5 +181,26 @@ def asbool(value):
     if value == -1:
         return False
     return bool(value)
+
+
+@contextmanager
+def context_with_request(context, cron):
+    # Create a request to work with
+    response = HTTPResponse(stdout=sys.stdout)
+
+    # Set up the request environment
+    env = cron.environ.get('REQUEST', {})
+
+    # Required environment variables
+    if 'SERVER_NAME' not in env:
+        env['SERVER_NAME'] = 'localhost'
+    if 'SERVER_PORT' not in env:
+        env['SERVER_PORT'] = '80'
+
+    request = HTTPRequest(sys.stdin, env, response)
+    context.REQUEST = request
+
+    yield context
+    del context.REQUEST
 
 # vim:set et sts=4 ts=4 tw=80:


### PR DESCRIPTION
When running a cron job, often we want or need a REQUEST object to be present on the context so that a script can successfully run. A patch to provide this as part of [plone.app.async](https://gist.github.com/rnixx/6027502) was rejected. This pull request adds a REQUEST object to the context while the job is being run, with the request configurable via the environment variables on the cron task.

Combined with [pull request 12](https://github.com/collective/collective.cron/pull/12) this lets us successfully call existing scripts at a schedule time without having to make further modifications to the scripts.